### PR TITLE
feat: add brightness-up, brightness-down, temperature-up and temperature-down commands

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,12 +109,12 @@ pub enum DeviceError {
 impl fmt::Display for DeviceError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            DeviceError::Unsupported => write!(f, "Device is not supported."),
+            DeviceError::Unsupported => write!(f, "Device is not supported"),
             DeviceError::InvalidBrightness(value) => {
-                write!(f, "Brightness in Lumen '{}' is not supported.", value)
+                write!(f, "Brightness {} lm is not supported", value)
             }
             DeviceError::InvalidTemperature(value) => {
-                write!(f, "Temperature in Kelvin '{}' is not supported.", value)
+                write!(f, "Temperature {} K is not supported", value)
             }
             DeviceError::HidError(error) => write!(f, "HID error occurred: {}", error),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ enum CliError {
     #[cfg(target_os = "linux")]
     IoError(std::io::Error),
     SerializationFailed(serde_json::Error),
-    BrightnessPrecentageCalculationFailed(TryFromIntError),
+    BrightnessPercentageCalculationFailed(TryFromIntError),
     DeviceNotFound,
 }
 
@@ -140,7 +140,7 @@ impl fmt::Display for CliError {
             #[cfg(target_os = "linux")]
             CliError::IoError(error) => write!(f, "Input/Output error: {}", error),
             CliError::SerializationFailed(error) => error.fmt(f),
-            CliError::BrightnessPrecentageCalculationFailed(error) => {
+            CliError::BrightnessPercentageCalculationFailed(error) => {
                 write!(f, "Failed to calculate brightness: {}", error)
             }
             CliError::DeviceNotFound => write!(f, "Device not found."),
@@ -292,7 +292,7 @@ fn handle_brightness_command(
                 device_handle.maximum_brightness_in_lumen().into(),
             )
             .try_into()
-            .map_err(CliError::BrightnessPrecentageCalculationFailed)?;
+            .map_err(CliError::BrightnessPercentageCalculationFailed)?;
 
             device_handle.set_brightness_in_lumen(brightness_in_lumen)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ enum Commands {
     /// Increases the brightness of your Logitech Litra device. The command will error if trying to increase the brightness beyond the device's maximum.
     #[clap(group = ArgGroup::new("brightness-up").required(true).multiple(false))]
     BrightnessUp {
-        #[clap(long, short, help = "The serial number of the Logitech Litra device")]
+        #[clap(long, short, help = "The serial number of the Logitech Litra dvice")]
         serial_number: Option<String>,
         #[clap(
             long,
@@ -68,7 +68,7 @@ enum Commands {
         #[clap(
             long,
             short,
-            help = "The number of percentage points to increase the brightness by",
+            help = "The number of percentage point to increase the brightness by",
             group = "brightness-up"
         )]
         percentage: Option<u8>,
@@ -411,7 +411,7 @@ fn handle_brightness_down_command(
     match (value, percentage) {
         (Some(_), None) => {
             let brightness_to_subtract = value.unwrap();
-            let new_brightness = current_brightness - brightness_to_subtract;
+            let new_brightness = current_brightness + brightness_to_subtract;
             device_handle.set_brightness_in_lumen(new_brightness)?;
         }
         (None, Some(_)) => {
@@ -449,7 +449,7 @@ fn handle_temperature_up_command(serial_number: Option<&str>, value: u16) -> Cli
     let current_temperature = device_handle.temperature_in_kelvin()?;
     let new_temperature = current_temperature + value;
 
-    device_handle.set_temperature_in_kelvin(new_temperature)?;
+    device_handle.set_brightness_in_lumen(new_temperature)?;
     Ok(())
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 716fab86fa55bbf7ed768222f9085347d458575f  | 
|--------|--------|

### Summary:
Added new commands to control brightness and temperature of Logitech Litra devices, including `BrightnessUp`, `BrightnessDown`, `TemperatureUp`, and `TemperatureDown`.

**Key points**:
- Added `BrightnessUp` and `BrightnessDown` commands in `src/main.rs` to increase or decrease brightness.
- Added `TemperatureUp` and `TemperatureDown` commands in `src/main.rs` to increase or decrease temperature.
- Implemented `handle_brightness_up_command` and `handle_brightness_down_command` in `src/main.rs`.
- Implemented `handle_temperature_up_command` and `handle_temperature_down_command` in `src/main.rs`.
- Updated `DeviceError` and `CliError` enums in `src/lib.rs` and `src/main.rs` respectively for new error cases.
- Modified `fmt::Display` implementations for `DeviceError` and `CliError` in `src/lib.rs` and `src/main.rs` respectively.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->